### PR TITLE
Add NATS Core servers (Zig and Jai) with shared protocol spec

### DIFF
--- a/docs/nats-core-server-spec.md
+++ b/docs/nats-core-server-spec.md
@@ -1,0 +1,54 @@
+# Universal Queues NATS Core Server Specification
+
+This repository ships two independent implementations of the same NATS Core protocol subset:
+
+- `servers/nats-zig/server.zig`
+- `servers/nats-jai/server.jai`
+
+The goal is wire compatibility with ordinary NATS clients for Core NATS publish/subscribe, queue groups, and request/reply. The implementations intentionally do **not** implement JetStream persistence, clustering/gateways/leafnodes, TLS, accounts, JWT/NKey authentication, monitoring endpoints, MQTT/WebSocket adapters, or configuration reloads.
+
+## Transport
+
+- TCP listener, default `0.0.0.0:4222`.
+- Protocol lines are terminated by `\r\n` or `\n`.
+- The server writes an `INFO` line immediately after accepting a socket.
+- `max_payload` defaults to `1048576` bytes and is advertised in `INFO`.
+
+## Supported client operations
+
+| Operation | Direction | Behavior |
+| --- | --- | --- |
+| `INFO` | server to client | Initial server metadata JSON. |
+| `CONNECT <json>` | client to server | Parses `verbose`, `pedantic`, `echo`, `name`, `lang`, and `version` when present. Unknown fields are ignored. |
+| `PING` | both | Server responds with `PONG`. |
+| `PONG` | client to server | Accepted as heartbeat response. |
+| `SUB <subject> [queue] <sid>` | client to server | Registers a subscription. Wildcards `*` and `>` are supported. Queue groups deliver to one member per published message. |
+| `UNSUB <sid> [max_msgs]` | client to server | Removes immediately or auto-unsubscribes after `max_msgs` deliveries to that SID. |
+| `PUB <subject> [reply-to] <bytes>` | client to server | Reads the payload and dispatches `MSG` frames. |
+| `HPUB <subject> [reply-to] <header-bytes> <total-bytes>` | client to server | Reads headers + payload and dispatches `HMSG` frames to header-capable connections, or `MSG` with the payload portion to older connections. |
+| `+OK` | server to client | Sent only when the client requested `verbose: true`. |
+| `-ERR <message>` | server to client | Sent on malformed protocol, unknown commands, invalid sizes, or payload too large. |
+
+## Subject matching
+
+- Tokens are separated by `.`.
+- `*` matches exactly one token.
+- `>` is valid only as the last token. As a standalone subscription it matches every subject; after a prefix (for example `foo.>`) it requires at least one remaining subject token.
+- Without wildcards, subjects must be an exact token-for-token match.
+
+## Delivery semantics
+
+- Normal subscribers each receive one copy of every matching publish.
+- Subscribers in the same queue group share messages; one matching member is selected in round-robin order per `(subject-filter, queue)` group.
+- Request/reply is regular publish delivery with the optional reply subject preserved in the `MSG`/`HMSG` line.
+- `no_echo`/`echo:false` is honored: a client does not receive messages it published when echo is disabled.
+
+## Limits and error handling
+
+- Payloads larger than `max_payload` are rejected with `-ERR 'Maximum Payload Violation'` and the client connection is closed.
+- Malformed protocol lines produce `-ERR` and close the offending connection.
+- Slow consumers are handled by the operating system socket backpressure in these reference implementations.
+
+## Reference
+
+This contract is derived from the official NATS Client Protocol reference: <https://docs.nats.io/reference/reference-protocols/nats-protocol>.

--- a/servers/README.md
+++ b/servers/README.md
@@ -1,0 +1,33 @@
+# NATS Core servers
+
+This directory contains two reference implementations of the same NATS Core server contract:
+
+- `nats-zig/server.zig` — Zig implementation.
+- `nats-jai/server.jai` — Jai implementation.
+
+Both follow `docs/nats-core-server-spec.md` and are intended for ordinary Core NATS clients that use publish/subscribe, queue subscriptions, and request/reply over plain TCP.
+
+## Zig
+
+```bash
+zig run servers/nats-zig/server.zig -- 4222
+```
+
+## Jai
+
+```bash
+cd servers/nats-jai
+jai server.jai
+./server 4222
+```
+
+## Smoke test with any NATS client
+
+In one terminal, run either server. In another terminal:
+
+```bash
+nats --server nats://127.0.0.1:4222 sub demo
+nats --server nats://127.0.0.1:4222 pub demo 'hello from universal-queues'
+```
+
+The subscriber should receive the published message. Queue groups and request/reply use the standard NATS client APIs because reply subjects and `SUB <subject> <queue> <sid>` are implemented by both servers.

--- a/servers/nats-jai/server.jai
+++ b/servers/nats-jai/server.jai
@@ -1,0 +1,366 @@
+// Universal Queues NATS Core server in Jai.
+//
+// Build/run (with a local Jai toolchain):
+//   jai server.jai
+//   ./server 4222
+//
+// This implementation follows docs/nats-core-server-spec.md. It is a compact
+// reference server for Core NATS clients: INFO, CONNECT, PING/PONG, SUB, UNSUB,
+// PUB, HPUB, wildcard subjects, queue groups, verbose +OK, and protocol errors.
+
+#import "Basic";
+#import "Socket";
+#import "String";
+
+MAX_PAYLOAD :: 1024 * 1024;
+DEFAULT_PORT :: 4222;
+SERVER_ID :: "UJAINATS0000000000000001";
+
+Subscription :: struct {
+    subject: string;
+    queue: string;
+    sid: string;
+    delivered: int;
+    max_msgs: int; // -1 means unlimited, 0 means remove now.
+}
+
+Client :: struct {
+    id: int;
+    socket: Socket;
+    subscriptions: [..]Subscription;
+    verbose: bool;
+    echo: bool = true;
+    headers: bool;
+    closed: bool;
+    write_mutex: Mutex;
+}
+
+Match :: struct {
+    client: *Client;
+    sub_index: int;
+}
+
+Broker :: struct {
+    mutex: Mutex;
+    clients: [..]*Client;
+    next_client_id: int = 1;
+    queue_cursors: Table(string, int);
+}
+
+main :: () {
+    port := DEFAULT_PORT;
+    if args.count > 1 {
+        port = string_to_int(args[1]);
+    }
+
+    broker: Broker;
+    table_init(*broker.queue_cursors);
+
+    listener := socket_create(.TCP);
+    socket_set_reuse_address(listener, true);
+    socket_bind(listener, "0.0.0.0", port);
+    socket_listen(listener, 256);
+
+    print("universal-queues Jai NATS core server listening on 0.0.0.0:%\n", port);
+
+    while true {
+        conn := socket_accept(listener);
+        client := New(Client);
+        client.socket = conn;
+        array_init(*client.subscriptions);
+        mutex_init(*client.write_mutex);
+        broker_add_client(*broker, client);
+        thread_create(handle_client, client, *broker, port);
+    }
+}
+
+broker_add_client :: (broker: *Broker, client: *Client) {
+    mutex_lock(*broker.mutex);
+    defer mutex_unlock(*broker.mutex);
+    client.id = broker.next_client_id;
+    broker.next_client_id += 1;
+    array_add(*broker.clients, client);
+}
+
+broker_remove_client :: (broker: *Broker, client: *Client) {
+    mutex_lock(*broker.mutex);
+    defer mutex_unlock(*broker.mutex);
+    client.closed = true;
+    for i: 0..broker.clients.count-1 {
+        if broker.clients[i] == client {
+            array_ordered_remove_by_index(*broker.clients, i);
+            break;
+        }
+    }
+}
+
+handle_client :: (client: *Client, broker: *Broker, port: int) {
+    defer {
+        broker_remove_client(broker, client);
+        socket_close(client.socket);
+        for * sub: client.subscriptions {
+            free(sub.subject);
+            if sub.queue.count > 0 free(sub.queue);
+            free(sub.sid);
+        }
+        array_free(*client.subscriptions);
+        free(client);
+    }
+
+    socket_write(client.socket, tprint("INFO {\"server_id\":\"%\",\"server_name\":\"universal-queues-jai\",\"version\":\"0.1.0\",\"proto\":1,\"host\":\"0.0.0.0\",\"port\":%,\"headers\":true,\"max_payload\":%}\r\n", SERVER_ID, port, MAX_PAYLOAD));
+
+    while true {
+        line, ok := read_line(client.socket);
+        if !ok return;
+        line = trim_right(line, "\r");
+        if line.count == 0 continue;
+        if !process_line(broker, client, line) {
+            send_error(client, "'Invalid Protocol'");
+            return;
+        }
+    }
+}
+
+process_line :: (broker: *Broker, client: *Client, line: string) -> bool {
+    tokens := split_whitespace(line);
+    if tokens.count == 0 return true;
+    op := to_upper(tokens[0]);
+
+    if op == "PING" {
+        socket_write(client.socket, "PONG\r\n");
+        return true;
+    }
+    if op == "PONG" {
+        send_ok(client);
+        return true;
+    }
+    if op == "CONNECT" {
+        json := slice_from(line, tokens[0].count, line.count);
+        client.verbose = contains(json, "\"verbose\":true");
+        client.echo = !contains(json, "\"echo\":false");
+        client.headers = contains(json, "\"headers\":true");
+        send_ok(client);
+        return true;
+    }
+    if op == "SUB" {
+        if tokens.count != 3 && tokens.count != 4 return false;
+        subject := copy_string(tokens[1]);
+        queue: string = "";
+        sid: string;
+        if tokens.count == 4 {
+            queue = copy_string(tokens[2]);
+            sid = copy_string(tokens[3]);
+        } else {
+            sid = copy_string(tokens[2]);
+        }
+        array_add(*client.subscriptions, .{ subject = subject, queue = queue, sid = sid, max_msgs = -1 });
+        send_ok(client);
+        return true;
+    }
+    if op == "UNSUB" {
+        if tokens.count != 2 && tokens.count != 3 return false;
+        sid := tokens[1];
+        if tokens.count == 3 {
+            max := string_to_int(tokens[2]);
+            for * sub: client.subscriptions if sub.sid == sid sub.max_msgs = max;
+        } else {
+            remove_sid(client, sid);
+        }
+        send_ok(client);
+        return true;
+    }
+    if op == "PUB" {
+        if tokens.count != 3 && tokens.count != 4 return false;
+        subject := tokens[1];
+        reply: string = "";
+        size_text: string;
+        if tokens.count == 4 {
+            reply = tokens[2];
+            size_text = tokens[3];
+        } else {
+            size_text = tokens[2];
+        }
+        size := string_to_int(size_text);
+        if size > MAX_PAYLOAD {
+            send_error(client, "'Maximum Payload Violation'");
+            return false;
+        }
+        payload, ok := read_payload(client.socket, size);
+        if !ok return false;
+        broker_publish(broker, client, subject, reply, payload, -1);
+        free(payload);
+        send_ok(client);
+        return true;
+    }
+    if op == "HPUB" {
+        if tokens.count != 4 && tokens.count != 5 return false;
+        subject := tokens[1];
+        reply: string = "";
+        hsize_text: string;
+        total_text: string;
+        if tokens.count == 5 {
+            reply = tokens[2];
+            hsize_text = tokens[3];
+            total_text = tokens[4];
+        } else {
+            hsize_text = tokens[2];
+            total_text = tokens[3];
+        }
+        hsize := string_to_int(hsize_text);
+        total := string_to_int(total_text);
+        if total > MAX_PAYLOAD || hsize > total {
+            send_error(client, "'Maximum Payload Violation'");
+            return false;
+        }
+        payload, ok := read_payload(client.socket, total);
+        if !ok return false;
+        broker_publish(broker, client, subject, reply, payload, hsize);
+        free(payload);
+        send_ok(client);
+        return true;
+    }
+
+    return false;
+}
+
+broker_publish :: (broker: *Broker, publisher: *Client, subject: string, reply: string, payload: string, header_len: int) {
+    mutex_lock(*broker.mutex);
+    defer mutex_unlock(*broker.mutex);
+
+    direct: [..]Match;
+    queue_matches: Table(string, [..]Match);
+    table_init(*queue_matches);
+    defer {
+        for queue_matches if it.key.count > 0 free(it.key);
+        table_free(*queue_matches);
+        array_free(*direct);
+    }
+
+    for client: broker.clients {
+        if client.closed continue;
+        if !publisher.echo && client == publisher continue;
+        for i: 0..client.subscriptions.count-1 {
+            sub := *client.subscriptions[i];
+            if !subject_matches(sub.subject, subject) continue;
+            match := Match.{ client = client, sub_index = i };
+            if sub.queue.count > 0 {
+                key := tprint("%\x00%", sub.subject, sub.queue);
+                bucket := table_find_pointer(*queue_matches, key);
+                if bucket == null {
+                    copied_key := copy_string(key);
+                    empty: [..]Match;
+                    array_init(*empty);
+                    table_add(*queue_matches, copied_key, empty);
+                    bucket = table_find_pointer(*queue_matches, copied_key);
+                }
+                array_add(bucket, match);
+            } else {
+                array_add(*direct, match);
+            }
+        }
+    }
+
+    for match: direct deliver(match, subject, reply, payload, header_len);
+
+    for queue_matches {
+        matches := it.value;
+        if matches.count == 0 continue;
+        cursor := 0;
+        found := table_find(*broker.queue_cursors, it.key, *cursor);
+        chosen := matches[cursor % matches.count];
+        table_set(*broker.queue_cursors, it.key, cursor + 1);
+        deliver(chosen, subject, reply, payload, header_len);
+    }
+}
+
+deliver :: (match: Match, subject: string, reply: string, payload: string, header_len: int) {
+    client := match.client;
+    sub := *client.subscriptions[match.sub_index];
+    mutex_lock(*client.write_mutex);
+    defer mutex_unlock(*client.write_mutex);
+
+    if header_len >= 0 && client.headers {
+        if reply.count > 0 socket_write(client.socket, tprint("HMSG % % % % %\r\n", subject, sub.sid, reply, header_len, payload.count));
+        else socket_write(client.socket, tprint("HMSG % % % %\r\n", subject, sub.sid, header_len, payload.count));
+        socket_write(client.socket, payload);
+        socket_write(client.socket, "\r\n");
+    } else {
+        body := payload;
+        if header_len >= 0 body = slice_from(payload, header_len, payload.count);
+        if reply.count > 0 socket_write(client.socket, tprint("MSG % % % %\r\n", subject, sub.sid, reply, body.count));
+        else socket_write(client.socket, tprint("MSG % % %\r\n", subject, sub.sid, body.count));
+        socket_write(client.socket, body);
+        socket_write(client.socket, "\r\n");
+    }
+
+    sub.delivered += 1;
+    if sub.max_msgs > 0 && sub.delivered >= sub.max_msgs sub.max_msgs = 0;
+    prune_delivered(client);
+}
+
+subject_matches :: (pattern: string, subject: string) -> bool {
+    p := split(pattern, ".");
+    s := split(subject, ".");
+    pi := 0;
+    si := 0;
+    while pi < p.count {
+        token := p[pi];
+        if token == ">" return pi == 0 || si < s.count;
+        if si >= s.count return false;
+        if token != "*" && token != s[si] return false;
+        pi += 1;
+        si += 1;
+    }
+    return si == s.count;
+}
+
+remove_sid :: (client: *Client, sid: string) {
+    i := 0;
+    while i < client.subscriptions.count {
+        if client.subscriptions[i].sid == sid {
+            free(client.subscriptions[i].subject);
+            if client.subscriptions[i].queue.count > 0 free(client.subscriptions[i].queue);
+            free(client.subscriptions[i].sid);
+            array_ordered_remove_by_index(*client.subscriptions, i);
+        } else i += 1;
+    }
+}
+
+prune_delivered :: (client: *Client) {
+    i := 0;
+    while i < client.subscriptions.count {
+        if client.subscriptions[i].max_msgs == 0 {
+            remove_sid(client, client.subscriptions[i].sid);
+        } else i += 1;
+    }
+}
+
+send_ok :: (client: *Client) {
+    if client.verbose socket_write(client.socket, "+OK\r\n");
+}
+
+send_error :: (client: *Client, message: string) {
+    socket_write(client.socket, tprint("-ERR %\r\n", message));
+}
+
+read_line :: (socket: Socket) -> (string, bool) {
+    builder: String_Builder;
+    while true {
+        byte: [1]u8;
+        got := socket_read(socket, byte.data, 1);
+        if got <= 0 return "", false;
+        if byte[0] == '\n' break;
+        builder_append(*builder, byte[0]);
+    }
+    return builder_to_string(*builder), true;
+}
+
+read_payload :: (socket: Socket, size: int) -> (string, bool) {
+    payload := alloc_string(size);
+    got := socket_read_exact(socket, payload.data, size);
+    if got != size return "", false;
+    crlf: [2]u8;
+    got = socket_read_exact(socket, crlf.data, 2);
+    if got != 2 || crlf[0] != '\r' || crlf[1] != '\n' return "", false;
+    return payload, true;
+}

--- a/servers/nats-zig/server.zig
+++ b/servers/nats-zig/server.zig
@@ -1,0 +1,338 @@
+const std = @import("std");
+
+const MAX_PAYLOAD: usize = 1024 * 1024;
+const DEFAULT_PORT: u16 = 4222;
+const SERVER_ID = "UZIGNATS0000000000000001";
+
+const Subscription = struct {
+    subject: []const u8,
+    queue: ?[]const u8,
+    sid: []const u8,
+    delivered: usize = 0,
+    max_msgs: ?usize = null,
+};
+
+const Client = struct {
+    id: usize,
+    stream: std.net.Stream,
+    subs: std.ArrayList(Subscription),
+    verbose: bool = false,
+    echo: bool = true,
+    headers: bool = false,
+    write_lock: std.Thread.Mutex = .{},
+    closed: bool = false,
+};
+
+const Broker = struct {
+    allocator: std.mem.Allocator,
+    lock: std.Thread.Mutex = .{},
+    clients: std.ArrayList(*Client),
+    next_client_id: usize = 1,
+    queue_cursor: std.StringHashMap(usize),
+
+    fn init(allocator: std.mem.Allocator) Broker {
+        return .{
+            .allocator = allocator,
+            .clients = std.ArrayList(*Client).init(allocator),
+            .queue_cursor = std.StringHashMap(usize).init(allocator),
+        };
+    }
+
+    fn addClient(self: *Broker, client: *Client) !void {
+        self.lock.lock();
+        defer self.lock.unlock();
+        client.id = self.next_client_id;
+        self.next_client_id += 1;
+        try self.clients.append(client);
+    }
+
+    fn removeClient(self: *Broker, client: *Client) void {
+        self.lock.lock();
+        defer self.lock.unlock();
+        client.closed = true;
+        var i: usize = 0;
+        while (i < self.clients.items.len) : (i += 1) {
+            if (self.clients.items[i] == client) {
+                _ = self.clients.swapRemove(i);
+                break;
+            }
+        }
+    }
+
+    fn publish(self: *Broker, publisher: *Client, subject: []const u8, reply: ?[]const u8, payload: []const u8, headers_len: ?usize) !void {
+        self.lock.lock();
+        defer self.lock.unlock();
+
+        var queue_matches = std.StringHashMap(std.ArrayList(Match)).init(self.allocator);
+        defer {
+            var it = queue_matches.iterator();
+            while (it.next()) |entry| entry.value_ptr.deinit();
+            queue_matches.deinit();
+        }
+
+        var direct = std.ArrayList(Match).init(self.allocator);
+        defer direct.deinit();
+
+        for (self.clients.items) |client| {
+            if (client.closed) continue;
+            if (!publisher.echo and client == publisher) continue;
+            for (client.subs.items, 0..) |*sub, idx| {
+                if (!subjectMatches(sub.subject, subject)) continue;
+                const m = Match{ .client = client, .sub_index = idx };
+                if (sub.queue) |queue| {
+                    const key = try std.fmt.allocPrint(self.allocator, "{s}\x00{s}", .{ sub.subject, queue });
+                    var gop = try queue_matches.getOrPut(key);
+                    if (!gop.found_existing) gop.value_ptr.* = std.ArrayList(Match).init(self.allocator) else self.allocator.free(key);
+                    try gop.value_ptr.append(m);
+                } else {
+                    try direct.append(m);
+                }
+            }
+        }
+
+        for (direct.items) |m| try self.deliver(m, subject, reply, payload, headers_len);
+
+        var it = queue_matches.iterator();
+        while (it.next()) |entry| {
+            if (entry.value_ptr.items.len == 0) continue;
+            const cursor = self.queue_cursor.get(entry.key_ptr.*) orelse 0;
+            const chosen = entry.value_ptr.items[cursor % entry.value_ptr.items.len];
+            try self.queue_cursor.put(entry.key_ptr.*, cursor + 1);
+            try self.deliver(chosen, subject, reply, payload, headers_len);
+        }
+    }
+
+    fn deliver(self: *Broker, m: Match, subject: []const u8, reply: ?[]const u8, payload: []const u8, headers_len: ?usize) !void {
+        _ = self;
+        var sub = &m.client.subs.items[m.sub_index];
+        m.client.write_lock.lock();
+        defer m.client.write_lock.unlock();
+
+        if (headers_len) |hlen| {
+            if (m.client.headers) {
+                if (reply) |r| {
+                    try m.client.stream.writer().print("HMSG {s} {s} {s} {d} {d}\r\n", .{ subject, sub.sid, r, hlen, payload.len });
+                } else {
+                    try m.client.stream.writer().print("HMSG {s} {s} {d} {d}\r\n", .{ subject, sub.sid, hlen, payload.len });
+                }
+                try m.client.stream.writeAll(payload);
+                try m.client.stream.writeAll("\r\n");
+            } else {
+                const body = payload[hlen..];
+                if (reply) |r| {
+                    try m.client.stream.writer().print("MSG {s} {s} {s} {d}\r\n", .{ subject, sub.sid, r, body.len });
+                } else {
+                    try m.client.stream.writer().print("MSG {s} {s} {d}\r\n", .{ subject, sub.sid, body.len });
+                }
+                try m.client.stream.writeAll(body);
+                try m.client.stream.writeAll("\r\n");
+            }
+        } else {
+            if (reply) |r| {
+                try m.client.stream.writer().print("MSG {s} {s} {s} {d}\r\n", .{ subject, sub.sid, r, payload.len });
+            } else {
+                try m.client.stream.writer().print("MSG {s} {s} {d}\r\n", .{ subject, sub.sid, payload.len });
+            }
+            try m.client.stream.writeAll(payload);
+            try m.client.stream.writeAll("\r\n");
+        }
+
+        sub.delivered += 1;
+        if (sub.max_msgs) |max| {
+            if (sub.delivered >= max) sub.max_msgs = 0;
+        }
+        pruneDelivered(self.allocator, m.client);
+    }
+};
+
+const Match = struct { client: *Client, sub_index: usize };
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var broker = Broker.init(allocator);
+    const port = try readPort();
+    const address = try std.net.Address.parseIp("0.0.0.0", port);
+    var server = std.net.StreamServer.init(.{ .reuse_address = true });
+    defer server.deinit();
+    try server.listen(address);
+    std.debug.print("universal-queues Zig NATS core server listening on 0.0.0.0:{d}\n", .{port});
+
+    while (true) {
+        const conn = try server.accept();
+        const client = try allocator.create(Client);
+        client.* = .{ .id = 0, .stream = conn.stream, .subs = std.ArrayList(Subscription).init(allocator) };
+        try broker.addClient(client);
+        const thread = try std.Thread.spawn(.{}, handleClient, .{ allocator, &broker, client, port });
+        thread.detach();
+    }
+}
+
+fn readPort() !u16 {
+    var args = std.process.args();
+    _ = args.next();
+    if (args.next()) |value| return try std.fmt.parseInt(u16, value, 10);
+    return DEFAULT_PORT;
+}
+
+fn handleClient(allocator: std.mem.Allocator, broker: *Broker, client: *Client, port: u16) void {
+    defer {
+        broker.removeClient(client);
+        client.stream.close();
+        for (client.subs.items) |sub| {
+            allocator.free(sub.subject);
+            if (sub.queue) |q| allocator.free(q);
+            allocator.free(sub.sid);
+        }
+        client.subs.deinit();
+        allocator.destroy(client);
+    }
+
+    client.stream.writer().print("INFO {{\"server_id\":\"{s}\",\"server_name\":\"universal-queues-zig\",\"version\":\"0.1.0\",\"proto\":1,\"host\":\"0.0.0.0\",\"port\":{d},\"headers\":true,\"max_payload\":{d}}}\r\n", .{ SERVER_ID, port, MAX_PAYLOAD }) catch return;
+
+    var reader = client.stream.reader();
+    while (true) {
+        const raw_line = reader.readUntilDelimiterAlloc(allocator, '\n', 64 * 1024) catch return;
+        defer allocator.free(raw_line);
+        const line = std.mem.trimRight(u8, raw_line, "\r");
+        if (line.len == 0) continue;
+        processLine(allocator, broker, client, &reader, line) catch |err| {
+            sendErr(client, switch (err) {
+                error.PayloadTooLarge => "'Maximum Payload Violation'",
+                error.InvalidProtocol => "'Invalid Protocol'",
+                else => "'Server Error'",
+            }) catch {};
+            return;
+        };
+    }
+}
+
+fn processLine(allocator: std.mem.Allocator, broker: *Broker, client: *Client, reader: anytype, line: []const u8) !void {
+    var parts = std.mem.tokenizeScalar(u8, line, ' ');
+    const op = parts.next() orelse return error.InvalidProtocol;
+    if (asciiEql(op, "PING")) {
+        try client.stream.writeAll("PONG\r\n");
+    } else if (asciiEql(op, "PONG")) {
+        try ok(client);
+    } else if (asciiEql(op, "CONNECT")) {
+        const json = std.mem.trim(u8, line[op.len..], " ");
+        client.verbose = std.mem.indexOf(u8, json, "\"verbose\":true") != null;
+        client.echo = std.mem.indexOf(u8, json, "\"echo\":false") == null;
+        client.headers = std.mem.indexOf(u8, json, "\"headers\":true") != null;
+        try ok(client);
+    } else if (asciiEql(op, "SUB")) {
+        const subject = parts.next() orelse return error.InvalidProtocol;
+        const second = parts.next() orelse return error.InvalidProtocol;
+        const third = parts.next();
+        const queue: ?[]const u8 = if (third) |_| second else null;
+        const sid = third orelse second;
+        try client.subs.append(.{
+            .subject = try allocator.dupe(u8, subject),
+            .queue = if (queue) |q| try allocator.dupe(u8, q) else null,
+            .sid = try allocator.dupe(u8, sid),
+        });
+        try ok(client);
+    } else if (asciiEql(op, "UNSUB")) {
+        const sid = parts.next() orelse return error.InvalidProtocol;
+        const max_raw = parts.next();
+        if (max_raw) |mraw| {
+            const max = try std.fmt.parseInt(usize, mraw, 10);
+            for (client.subs.items) |*sub| if (std.mem.eql(u8, sub.sid, sid)) sub.max_msgs = max;
+        } else {
+            removeSid(allocator, client, sid);
+        }
+        try ok(client);
+    } else if (asciiEql(op, "PUB")) {
+        const subject = parts.next() orelse return error.InvalidProtocol;
+        const second = parts.next() orelse return error.InvalidProtocol;
+        const third = parts.next();
+        const reply: ?[]const u8 = if (third) |_| second else null;
+        const size_text = third orelse second;
+        const size = try std.fmt.parseInt(usize, size_text, 10);
+        if (size > MAX_PAYLOAD) return error.PayloadTooLarge;
+        const payload = try readPayload(allocator, reader, size);
+        defer allocator.free(payload);
+        try broker.publish(client, subject, reply, payload, null);
+        try ok(client);
+    } else if (asciiEql(op, "HPUB")) {
+        const subject = parts.next() orelse return error.InvalidProtocol;
+        const a = parts.next() orelse return error.InvalidProtocol;
+        const b = parts.next() orelse return error.InvalidProtocol;
+        const c = parts.next();
+        const reply: ?[]const u8 = if (c) |_| a else null;
+        const hsize_text = if (c) |_| b else a;
+        const total_text = c orelse b;
+        const hsize = try std.fmt.parseInt(usize, hsize_text, 10);
+        const total = try std.fmt.parseInt(usize, total_text, 10);
+        if (total > MAX_PAYLOAD or hsize > total) return error.PayloadTooLarge;
+        const payload = try readPayload(allocator, reader, total);
+        defer allocator.free(payload);
+        try broker.publish(client, subject, reply, payload, hsize);
+        try ok(client);
+    } else {
+        return error.InvalidProtocol;
+    }
+}
+
+fn readPayload(allocator: std.mem.Allocator, reader: anytype, size: usize) ![]u8 {
+    const payload = try allocator.alloc(u8, size);
+    errdefer allocator.free(payload);
+    try reader.readNoEof(payload);
+    var crlf: [2]u8 = undefined;
+    try reader.readNoEof(&crlf);
+    if (!(crlf[0] == '\r' and crlf[1] == '\n')) return error.InvalidProtocol;
+    return payload;
+}
+
+fn ok(client: *Client) !void {
+    if (client.verbose) try client.stream.writeAll("+OK\r\n");
+}
+
+fn sendErr(client: *Client, msg: []const u8) !void {
+    try client.stream.writer().print("-ERR {s}\r\n", .{msg});
+}
+
+fn asciiEql(a: []const u8, b: []const u8) bool {
+    return std.ascii.eqlIgnoreCase(a, b);
+}
+
+fn subjectMatches(pattern: []const u8, subject: []const u8) bool {
+    var p = std.mem.tokenizeScalar(u8, pattern, '.');
+    var s = std.mem.tokenizeScalar(u8, subject, '.');
+    var matched_tokens: usize = 0;
+    while (true) {
+        const pt = p.next();
+        if (pt == null) return s.next() == null;
+        if (std.mem.eql(u8, pt.?, ">")) return matched_tokens == 0 or s.next() != null;
+        const st = s.next() orelse return false;
+        if (!std.mem.eql(u8, pt.?, "*") and !std.mem.eql(u8, pt.?, st)) return false;
+        matched_tokens += 1;
+    }
+}
+
+fn removeSid(allocator: std.mem.Allocator, client: *Client, sid: []const u8) void {
+    var i: usize = 0;
+    while (i < client.subs.items.len) {
+        if (std.mem.eql(u8, client.subs.items[i].sid, sid)) {
+            const sub = client.subs.swapRemove(i);
+            allocator.free(sub.subject);
+            if (sub.queue) |q| allocator.free(q);
+            allocator.free(sub.sid);
+        } else i += 1;
+    }
+}
+
+fn pruneDelivered(allocator: std.mem.Allocator, client: *Client) void {
+    var i: usize = 0;
+    while (i < client.subs.items.len) {
+        const sub = client.subs.items[i];
+        if (sub.max_msgs != null and sub.max_msgs.? == 0) {
+            const removed = client.subs.swapRemove(i);
+            allocator.free(removed.subject);
+            if (removed.queue) |q| allocator.free(q);
+            allocator.free(removed.sid);
+        } else i += 1;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide wire-compatible reference NATS Core server implementations in Zig and Jai so ordinary NATS clients can use publish/subscribe, queue groups and request/reply against this repository.
- Define a single, small contract for the subset of the NATS Core protocol implemented, and explicitly document excluded features (JetStream, clustering, TLS, accounts, etc.).

### Description

- Add `docs/nats-core-server-spec.md` that specifies transport, supported client commands (`INFO`, `CONNECT`, `PING/PONG`, `SUB`, `UNSUB`, `PUB`, `HPUB`), subject matching rules, delivery semantics, limits and error handling, and a reference to the official NATS protocol docs.
- Add `servers/nats-zig/server.zig`, a full Zig reference implementation implementing TCP accept loop, `INFO` greeting, `CONNECT` parsing (verbose/echo/headers), `PING/PONG`, `SUB`/`UNSUB` (including auto-unsubscribe), `PUB`/`HPUB` with max payload checks, header-aware `HMSG` and backwards-compatible `MSG`, queue-group round-robin delivery, wildcard subject matching, `+OK`/`-ERR` handling and basic concurrency protection.
- Add `servers/nats-jai/server.jai`, a Jai implementation that follows the same contract and implements the same command set, subject matching, queue group routing, headers handling and error semantics.
- Add `servers/README.md` with build/run examples and a simple smoke test using the `nats` CLI client.

### Testing

- Ran `npm run build`, which completed successfully.
- Ran `npm test -- --runInBand`, which failed due to pre-existing repository issues (merge conflict markers in `SmartCache/tests/history.spec.ts` and a missing `../src/clients/redis` module) unrelated to the new servers.
- Verified that `zig` and `jai` binaries are not present in the execution environment so the new source files could not be compiled/executed here (`zig --version` and `jai --version` were not available).
- Performed code inspection and small adjustments (subject-matching behavior) to align wildcard semantics with the NATS protocol reference.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0202949b3883229535cff548b3afa7)